### PR TITLE
Fix API Broken in Firefox 127.0.X

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,7 @@ javascript:(async function togglePreview() {
       namedDest in destinations
         ? destinations[namedDest]
         : JSON.parse(namedDest);
-    const pageNumber = app.pdfLinkService._cachedPageNumber(explicitDest[0]);
-
+    const pageNumber = app.pdfDocument.cachedPageNumber(explicitDest[0]);
     app.pdfDocument.getPage(pageNumber).then(function (page) {
       const tempViewport = page.getViewport({ scale: 1.0 });
       const height = tempViewport.height * 1.2 * app.pdfViewer.currentScale;


### PR DESCRIPTION
Fix issue : https://github.com/belinghy/PDFRefPreview/issues/5#issue-2386200059